### PR TITLE
map thumbnails in k8s environment do not have site prefix, treat them…

### DIFF
--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -87,7 +87,12 @@ class Map < ActiveRecord::Base
   end
 
   def thumb_url
-    (APP_CONFIG['site_prefix'] || "") + self.upload.url(:thumb)
+    thumb = self.upload.url(:thumb)
+    if thumb.start_with?('http')
+      thumb
+    else
+      (APP_CONFIG['site_prefix'] || "") + thumb
+    end
   end
   
   def download_remote_image


### PR DESCRIPTION
… differently