### PR TITLE
Add date control slider

### DIFF
--- a/app/assets/javascripts/warp.ol.js
+++ b/app/assets/javascripts/warp.ol.js
@@ -265,6 +265,7 @@ var DateControl = function(opts) {
     var num = Number(e.target.value);
     if (num){
      applyFilter(String(num));
+     updateSlider(num);
     }
   }
 
@@ -323,6 +324,18 @@ function applyFilter(date_str){
       olms.setFilter(to_map, layersToFilter[i],  newFilters)
 
     }
+}
+
+function updateSlider(num){
+  var controls = to_map.getControls().getArray();
+  var datecontrol;
+  for (var a=0; a<controls.length;a++){
+    if (controls[a].constructor.name == "DateControl"){
+      datecontrol = controls[a];
+      break;
+    }
+  }
+  jQuery("#"+datecontrol.slider_div_id).slider("value", num)
 }
 
 

--- a/app/assets/javascripts/warp.ol.js
+++ b/app/assets/javascripts/warp.ol.js
@@ -244,9 +244,11 @@ AddLayerControl.prototype.constructor = AddLayerControl;
 
 var DateControl = function(opts) {
   var options = opts || {};
+  this.slider_div_id = "date-slider"
+  this.input_id = "date-input"
 
   var input = document.createElement("input");
-  input.id = "date-input";
+  input.id = this.input_id;
   input.pattern="^[12][0-9]{3}$"
   input.value = options.date || "1850";
   input.title = I18n["warp"]["enter_year"];
@@ -267,6 +269,16 @@ var DateControl = function(opts) {
   }
 
   input.addEventListener("input", handleChangeDate, false);
+
+  if (options.slider){
+    this.slider = true;
+    var sliderdiv = document.createElement("div");
+    sliderdiv.id = this.slider_div_id;
+    var handle =  document.createElement("div");
+    handle.className = "ui-slider-handle";
+    sliderdiv.appendChild(handle);
+    element.appendChild(sliderdiv);
+  }
 
   ol.control.Control.call(this, {
     element: element,
@@ -446,7 +458,8 @@ function init() {
     date = depicts_year
   }
   var dateControl = new DateControl({
-    date: date
+    date: date,
+    slider: true
   });
 
   antique_layer = antique_layer_path;
@@ -481,6 +494,23 @@ function init() {
        date = depicts_year
      }
      applyFilter(date);
+
+    //set up slider
+    if (dateControl.slider) {
+      jQuery("#"+dateControl.slider_div_id).slider({
+        value: date,
+        range: "min",
+        max: 2020,
+        min: 1500,
+        step: 5,
+        slide: function(e, ui) {
+          applyFilter(String(ui.value));
+          jQuery("#"+dateControl.input_id).val(ui.value)
+        }
+      });
+    }
+
+
    });
 
 

--- a/app/assets/javascripts/warped.js
+++ b/app/assets/javascripts/warped.js
@@ -20,8 +20,11 @@ function get_map_layer(layerid){
 
 var DateControl = function(opts) {
   var options = opts || {};
+  this.slider_div_id = "warped-date-slider"
+  this.input_id = "warped-date-input"
 
   var input = document.createElement("input");
+  input.id = this.input_id;
   input.pattern="^[12][0-9]{3}$"
   input.value = options.date || "1850";
   input.title = I18n["warp"]["enter_year"];
@@ -37,11 +40,21 @@ var DateControl = function(opts) {
   var handleChangeDate = function(e){
     var num = Number(e.target.value);
     if (num){
-     applyFilter(String(num));
+     applyFilterWarped(String(num));
     }
   }
 
   input.addEventListener("input", handleChangeDate, false);
+
+  if (options.slider){
+    this.slider = true;
+    var sliderdiv = document.createElement("div");
+    sliderdiv.id = this.slider_div_id;
+    var handle =  document.createElement("div");
+    handle.className = "ui-slider-handle";
+    sliderdiv.appendChild(handle);
+    element.appendChild(sliderdiv);
+  }
 
   ol.control.Control.call(this, {
     element: element,
@@ -169,7 +182,8 @@ function warpedinit() {
     date = depicts_year
   }
   var dateControl = new DateControl({
-    date: date
+    date: date,
+    slider: true
   });
   
 
@@ -227,13 +241,28 @@ function warpedinit() {
     if (depicts_year.length > 0 && Number(depicts_year)){
       date = depicts_year
     }
-    applyFilter(date);
+    applyFilterWarped(date);
+    //set up slider
+    if (dateControl.slider) {
+      jQuery("#"+dateControl.slider_div_id).slider({
+        value: date,
+        range: "min",
+        max: 2020,
+        min: 1500,
+        step: 5,
+        slide: function(e, ui) {
+          applyFilterWarped(String(ui.value));
+          jQuery("#"+dateControl.input_id).val(ui.value)
+        }
+      });
+    }
+    
   });
 
   
 } //warpedinit
 
-function applyFilter(date_str){
+function applyFilterWarped(date_str){
   var startProp  = 'start_date';
   var endProp    = 'end_date';
    

--- a/app/assets/javascripts/warped.js
+++ b/app/assets/javascripts/warped.js
@@ -41,6 +41,7 @@ var DateControl = function(opts) {
     var num = Number(e.target.value);
     if (num){
      applyFilterWarped(String(num));
+     updateSliderWarped(num);
     }
   }
 
@@ -283,6 +284,18 @@ function applyFilterWarped(date_str){
       olms.setFilter(warpedmap, layersToFilter[i],  newFilters)
 
     }
+}
+
+function updateSliderWarped(num){
+  var controls = warpedmap.getControls().getArray();
+  var datecontrol;
+  for (var a=0; a<controls.length;a++){
+    if (controls[a].constructor.name == "DateControl"){
+      datecontrol = controls[a];
+      break;
+    }
+  }
+  jQuery("#"+datecontrol.slider_div_id).slider("value", num)
 }
 
 

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -2248,6 +2248,7 @@ div.layer-maps-col {
 .date-control {
   top: 0.7em;
   right: 0.5em;
+  height: 2.2em;
   input {
     width: 75px;
   }
@@ -2260,3 +2261,17 @@ div.layer-maps-col {
   top: 3em;
 }
 
+#to_map  .layer-switcher {
+  top: 7em !important;
+}
+
+#date-slider, #warped-date-slider {
+  top: 0.7em;
+  height: 8px;
+}
+
+#date-slider .ui-slider-handle, #warped-date-slider  .ui-slider-handle{
+  height: 15px;
+  width: 10px;
+  top: -4px;
+}

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -2274,4 +2274,5 @@ div.layer-maps-col {
   height: 15px;
   width: 10px;
   top: -4px;
+  margin-left: -4px;
 }


### PR DESCRIPTION
This extends the date filter to the rectify and preview views to add a small slider under the text box.  Sliding the slider changes the date filter on the vector tiles

![image](https://user-images.githubusercontent.com/48941/103306844-7221a980-4a06-11eb-8005-882c5b69399c.png)

The slider can be disabled for the date control.  Updating the text input box also updates the slider (and vice versa). 

The slider (using the existing jquery slider library used for the opacity control) is configurable and is currently set 1500 to 2020 with a step of 5 years.

Possible improvements could be done to set the Min and Max to be come from the range of available maps, similar to the time filter on the map search. i.e.
![image](https://user-images.githubusercontent.com/48941/103307405-d5f8a200-4a07-11eb-99b3-efba622d2cf5.png)

Or to make the min and max configurable from the app settings (application.yml file) 
