### PR TITLE
Make roads at ~z21 look larger. Add major roads at low zooms. Increase zoom level for warped map to 21

### DIFF
--- a/app/assets/antique/antique_style_local.json
+++ b/app/assets/antique/antique_style_local.json
@@ -68,23 +68,37 @@
       "source-layer":"minor_roads",
       "type":"line",
       "minzoom":16,
-      "maxzoom":20
+      "maxzoom":21
     },
     {
-      "paint":{"line-color":"#444444", "line-width": ["interpolate", ["linear"], ["zoom"], 14, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 6, 4], 19, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 29, 24] ] },
+      "paint":{"line-color":"#444444",  "line-width": ["interpolate", ["linear"], ["zoom"], 14, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 6, 4], 18, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 29, 24], 20, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 56, 56] ] },
       "source-layer":"roads",
       "id":"roads_casing_major",
       "source":"antique",
       "type":"line",
-      "minzoom":14,
+      "minzoom":13,
       "maxzoom":21
     },
-
+    
     {
-      "paint":{"line-color":"#e8e0c8",
-      "line-width": ["interpolate", ["linear"], ["zoom"], 14, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 5, 2], 19, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 28, 23] ]},
+      "paint":{"line-color":"#e8e0c8", 
+      "line-width": ["interpolate", ["linear"], ["zoom"], 14, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 5, 2], 18, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 28, 23], 20, ["match", ["get", "type"],["motorway","trunk","primary","secondary" ], 55, 55] ] },
       "id":"roads_centre_major",
       "ref":"roads_casing_major"
+    },
+    {
+      "paint":{"line-color":"#444444", "line-width":{"stops":[[8,2],[14,6]]}},
+      "id":"roads_casing_major2",
+      "source":"antique",
+      "source-layer":"major_roads",
+      "type":"line",
+      "minzoom":8,
+      "maxzoom":13
+    },
+    {
+      "paint":{"line-color":"#e8e0c8","line-width":{"stops":[[8,1],[14,5]]}},
+      "id":"roads_centre_major2",
+      "ref":"roads_casing_major2"
     },
 
     {

--- a/app/assets/javascripts/warp.ol.js
+++ b/app/assets/javascripts/warp.ol.js
@@ -300,7 +300,9 @@ var layersToFilter = [
   "road_names",
   "minor_roads",
   "roads_casing_major",
-  "roads_centre_major"
+  "roads_centre_major",
+  "roads_casing_major2",
+  "roads_centre_major2"
 ];
 
 function applyFilter(date_str){

--- a/app/assets/javascripts/warped.js
+++ b/app/assets/javascripts/warped.js
@@ -80,7 +80,9 @@ var layersToFilter = [
   "road_names",
   "minor_roads",
   "roads_casing_major",
-  "roads_centre_major"
+  "roads_centre_major",
+  "roads_casing_major2",
+  "roads_centre_major2"
 ];
 
 
@@ -169,7 +171,7 @@ function warpedinit() {
     view: new ol.View({
       center: ol.extent.getCenter(warped_extent),
       minZoom: 2,
-      maxZoom: 20,
+      maxZoom: 21,
       zoom: 4
     })
   });


### PR DESCRIPTION
Roads will appear a bit bigger when zoomed in.

Before:

![image](https://user-images.githubusercontent.com/48941/103369472-22a0b380-4ac2-11eb-86df-a113ab72004c.png)

After: 

![image](https://user-images.githubusercontent.com/48941/103369379-e5d4bc80-4ac1-11eb-82b9-6ddaa5716a66.png)


This pull request also adds in the major roads layer (motorways) visible when zoomed out, and changes the preview map max zoom to 21 to match the rectify map. It also changes minor roads to be visible at z21. 